### PR TITLE
Inline formatting support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Quick and easy customizable terminal logs for your application.
 
 Welcome to Notiblocks, a versatile Python library designed to enhance terminal logging with customizable and intuitive features.
 
+
+### Documentation
+If you want to **learn** how to use `notiblocks`, check the [`documentation`](https://app.gitbook.com/o/4FBvhI5UXLbq0HL9OCTS/s/z6b70RGC8WhxZqoCAV0k/)
 ### What is Notiblocks?
 
 Notiblocks is more than just a logging library; it's a powerful tool that simplifies and elevates your terminal logging experience. It offers a user-friendly interface for creating custom, eye-catching logs, allowing developers to seamlessly integrate informative and visually appealing messages into their applications.

--- a/example.py
+++ b/example.py
@@ -23,7 +23,7 @@ def main():
     nb_handler = NBHandler(nb_conf)
 
     # You could even format things inline
-    print(nb_handler.success(ILFormatter.format(message="This is a $TEST$ successful message", args=["red"])))
+    print(nb_handler.success(ILFormatter.format("This is a $TEST$ successful message", ["red"])))
 
     print(nb_handler.fail("And this is a failed message"))
     print(nb_handler.warn("But this is a warning message"))

--- a/example.py
+++ b/example.py
@@ -22,14 +22,9 @@ def main():
 
     nb_handler = NBHandler(nb_conf)
 
-    # TODO: Implement the ILConfig and the ILFormatter classes
-    il_config = ILConfig(
-        color="red"
-    )
+    # You could even format things inline
+    print(nb_handler.success(ILFormatter.format(message="This is a $TEST$ successful message", args=["red"])))
 
-    il_formatter = ILFormatter()
-
-    print(nb_handler.success(il_formatter.format("This is a $TEST$ successful message", [il_config])))
     print(nb_handler.fail("And this is a failed message"))
     print(nb_handler.warn("But this is a warning message"))
     print(nb_handler.log("This is a logged message."))

--- a/notiblocks/__init__.py
+++ b/notiblocks/__init__.py
@@ -1,4 +1,4 @@
 from notiblocks.main.nb_config import NBConfig
 from notiblocks.main.nb_handler import NBHandler
 from notiblocks.main.inline_formatting.il_config import ILConfig
-from notiblcoks.main.inline_formatting.il_formatter import ILFormatter
+from notiblocks.main.inline_formatting.il_formatter import ILFormatter

--- a/notiblocks/main/inline_formatting/il_formatter.py
+++ b/notiblocks/main/inline_formatting/il_formatter.py
@@ -1,8 +1,8 @@
 # Inline formatter class, wrapper of the il_config
-from il_config import ILConfig
+from .il_config import ILConfig
 
 from ..ansi import ANSI
-from .enums.colors.fgcolors import FGColors
+from ..enums.colors.fgcolors import FGColors
 from ..constants import RESET_STYLE
 
 DEFAULT_COLOR = "none"
@@ -35,7 +35,7 @@ class ILFormatter:
 
         
     @staticmethod
-    def format(self, message: str, args: list) -> str:
+    def format(message: str, args: list) -> str:
 
         message_args = message.split('$')
         inline_configurations = [] # holder for the configuration classes

--- a/notiblocks/main/inline_formatting/il_formatter.py
+++ b/notiblocks/main/inline_formatting/il_formatter.py
@@ -5,7 +5,7 @@ from ..ansi import ANSI
 from ..enums.colors.fgcolors import FGColors
 from ..constants import RESET_STYLE
 
-DEFAULT_COLOR = "none"
+DEFAULT_COLOR = None
 
 class ILFormatter:
     """
@@ -23,10 +23,10 @@ class ILFormatter:
         pass
 
     # Private method for conversion between ilconfig and string
-    def __convert_formats(inline_configurations: list) -> str:
+    def convert_formats(inline_configurations: list) -> str:
         out = ""
         for element in inline_configurations:
-            if element.color == none:
+            if element.color == None:
                 out += f"{RESET_STYLE}{element.text}"
             else:
                 out += f"{ANSI.color_text(FGColors[element.color].value)}{element.text}"
@@ -40,11 +40,14 @@ class ILFormatter:
         message_args = message.split('$')
         inline_configurations = [] # holder for the configuration classes
 
+        configuration_args = 0
+
         # Define the configurations
         for i in range(0, len(message_args)):
             if i % 2 != 0:
-                inline_configurations[i] = ILConfig(message_args[i], args[i].color.lower())
+                inline_configurations.append(ILConfig(message_args[i], args[configuration_args].lower()))
+                configuration_args += 1
             else:
-                inline_configurations[i] = ILConfig(message_args[i], DEFAULT_COLOR)
+                inline_configurations.append(ILConfig(message_args[i], DEFAULT_COLOR))
 
-        return __convert_formats(inline_configurations)
+        return ILFormatter.convert_formats(inline_configurations)


### PR DESCRIPTION
Inline formatting support added for the next version (`0.0.3`), current problem is that for now we could only format separate parts of the message, and only "color" them. 

This implementation introduces two new classes
* `ILConfig` - class, that holds information about the inline formatting.
* `ILFormatter` - introduces a `.format()` static method, that allows you to use the inline formatting functionality.

The mentioned methods are going trough a lot of changes, and for sure they are going to be made more stable.