### PR TITLE
New exception whenever you try to log an empty message

### DIFF
--- a/notiblocks/main/_error.py
+++ b/notiblocks/main/_error.py
@@ -19,3 +19,7 @@ class InvalidFormatError(NBError, RuntimeError):
 class InvalidOperationTypeError(NBError, RuntimeError):
     def __str__(self) -> str:
         return f"{ANSI.background(BG_RED)}{ANSI.color_text(FG_YELLOW)}[{ANSI.color_text(FG_WHITE)}EXCEPTION{ANSI.color_text(FG_YELLOW)}]{ANSI.color_text(FG_WHITE)}{self._message}{RESET_STYLE}"
+
+class InvalidMessageError(NBError, RuntimeError):
+    def __str__(self) -> str:
+        return f"{ANSI.background(BG_RED)}{ANSI.color_text(FG_YELLOW)}[{ANSI.color_text(FG_WHITE)}EXCEPTION{ANSI.color_text(FG_YELLOW)}]{ANSI.color_text(FG_WHITE)}{self._message}{RESET_STYLE}"

--- a/notiblocks/main/_logger.py
+++ b/notiblocks/main/_logger.py
@@ -5,6 +5,8 @@ from ._nb_config import NBConfig
 
 from enum import Enum
 
+from ._error import InvalidSignError
+
 DEFAULT_LOGGER_SIGN = '[+]'
 
 class NBLogLevel(Enum):
@@ -50,7 +52,7 @@ class Logger:
             sign = DEFAULT_LOGGER_SIGN # TODO: Format the sign trough the nbconfig
 
         if message.trim == '':
-            pass # TODO: Throw and handle an exception
+            raise InvalidMessageError("The message could not be empty!")
 
         # Check the level types
         if level.trim().lower() == "success":


### PR DESCRIPTION
### Description
New error type is created and raised whenever you try to log an empty message. *You shouldn't do that, right?*

### Changes
Changes proposed in this pull request:
* `InvalidMessageError` type is created and raised in the `_logger` module

### Pull request status
 - [X] Implementation
 - [X] Unit tests
 - [X] Exception Handling
